### PR TITLE
Fix gazebo

### DIFF
--- a/khan_control/launch/control.launch
+++ b/khan_control/launch/control.launch
@@ -5,12 +5,12 @@
 
   <node name="base_controller_spawner" pkg="controller_manager" type="spawner" args="khan_joint_publisher khan_velocity_controller"/>
 
-  <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization">
+  <!--<node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization">
     <rosparam command="load" file="$(find khan_control)/config/localization.yaml" />
   </node>
 
   <node pkg="interactive_marker_twist_server" type="marker_server" name="twist_marker_server" output="screen"/>
-
+  -->
   <node pkg="twist_mux" type="twist_mux" name="twist_mux">
     <rosparam command="load" file="$(find khan_control)/config/twist_mux.yaml" />
     <remap from="cmd_vel_out" to="khan_velocity_controller/cmd_vel"/>

--- a/khan_control/launch/control.launch
+++ b/khan_control/launch/control.launch
@@ -3,7 +3,7 @@
 
   <rosparam command="load" file="$(find khan_control)/config/control.yaml" />
 
-  <node name="base_controller_spawner" pkg="controller_manager" type="spawner" args="khan_joint_publisher khan_velocity_controller --shutdown-timeout 3"/>
+  <node name="base_controller_spawner" pkg="controller_manager" type="spawner" args="khan_joint_publisher khan_velocity_controller"/>
 
   <node pkg="robot_localization" type="ekf_localization_node" name="ekf_localization">
     <rosparam command="load" file="$(find khan_control)/config/localization.yaml" />

--- a/khan_description/launch/description.launch
+++ b/khan_description/launch/description.launch
@@ -25,7 +25,9 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 -->
 <launch>
 
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(find khan_description)/urdf/description.xacro'" />
+  <arg name="is_sim" default="0" />
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find khan_description)/urdf/description.xacro'" unless="$(arg is_sim)"/>
+  <param name="robot_description" command="$(find xacro)/xacro.py '$(find khan_description)/urdf/khan.gazebo.xacro'" if="$(arg is_sim)"/>
 
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 

--- a/khan_description/urdf/khan.gazebo.xacro
+++ b/khan_description/urdf/khan.gazebo.xacro
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+Software License Agreement (BSD)
+
+\file      description.gazebo.xacro
+\authors   Coleman Knabe <csknabe@gmail.com> based on work by Paul Bovbel <pbovbel@clearpathrobotics.com, Devon Ash <dash@clearpathrobotics.com>
+\copyright Copyright (c) 2015, Clearpath Robotics, Inc., All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+   following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+   following disclaimer in the documentation and/or other materials provided with the distribution.
+ * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or promote
+   products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WAR-
+RANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, IN-
+DIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<robot name="khan_robot_gazebo" xmlns:xacro="http://ros.org/wiki/xacro">
+
+  <xacro:include filename="$(find khan_description)/urdf/khan.urdf.xacro" />
+
+  <!-- Gazebo plugin for ROS Control -->
+  <gazebo>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+      <robotNamespace>/</robotNamespace>
+    </plugin>
+  </gazebo>
+
+  <xacro:khan_robot />
+
+  <xacro:khan_robot_gazebo />
+
+</robot>

--- a/khan_launch/launch/khan_gazebo.launch
+++ b/khan_launch/launch/khan_gazebo.launch
@@ -11,6 +11,10 @@
     <arg name="world_name" value="$(arg world_name)"/>
   </include>
 
-  <include file="$(find khan_description)/launch/description.launch" />
+  <include file="$(find khan_description)/launch/description.launch">
+    <arg name="is_sim" value="1" />
+  </include>
+
+  <include file="$(find khan_control)/launch/control.launch" />
   <node name="spawn_robot" pkg="gazebo_ros" type="spawn_model" args="-urdf -model khan -param robot_description -x $(arg x) -y $(arg y) -z $(arg z) -R $(arg roll) -P $(arg pitch) -Y $(arg yaw)" />
 </launch>


### PR DESCRIPTION
This fixes Gazebo launch with ROS Controllers. Note that This requires cloning and building the gazebo_ros_pkgs in the Jade release configuration to use Gazebo 4 under Indigo.
