### PR TITLE
Add controller

### DIFF
--- a/khan_control/CMakeLists.txt
+++ b/khan_control/CMakeLists.txt
@@ -4,8 +4,18 @@ project(khan_control)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  sensor_msgs
+  hardware_interface
+  controller_manager
+  dynamic_reconfigure
+  transmission_interface
+  control_toolbox
+  urdf
 )
+
+find_package(Boost REQUIRED COMPONENTS thread)
 
 ###################################
 ## catkin specific configuration ##
@@ -19,9 +29,16 @@ find_package(catkin REQUIRED
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES khan_platform
-#  CATKIN_DEPENDS roscpp rospy std_msgs
+ CATKIN_DEPENDS roscpp sensor_msgs
 #  DEPENDS system_lib
 )
+
+include_directories(include ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+
+add_library(khan_hwintf src/KHANHWInterface.cpp)
+
+add_executable(khan_control src/KHANPythonControl.cpp)
+target_link_libraries(khan_control khan_hwintf ${Boost_LIBRARIES} ${catkin_LIBRARIES})
 
 #############
 ## Install ##
@@ -38,11 +55,11 @@ catkin_package(
 # )
 
 ## Mark executables and/or libraries for installation
-# install(TARGETS khan_platform khan_platform_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(TARGETS khan_hwintf khan_control
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
 install(DIRECTORY config launch

--- a/khan_control/config/example_khan.yaml
+++ b/khan_control/config/example_khan.yaml
@@ -1,0 +1,15 @@
+front_left_wheel:
+  p: 0.01
+  i: 0.01
+  d: 0.01
+  i_clamp: 0.0
+front_right_wheel:
+  p: 0.01
+  i: 0.01
+  d: 0.01
+  i_clamp: 0.0
+back_left_wheel:
+  p: 0.01
+  i: 0.01
+  d: 0.01
+  i_clamp: 0.0

--- a/khan_control/config/example_khan.yaml
+++ b/khan_control/config/example_khan.yaml
@@ -8,7 +8,12 @@ front_right_wheel:
   i: 0.01
   d: 0.01
   i_clamp: 0.0
-back_left_wheel:
+rear_left_wheel:
+  p: 0.01
+  i: 0.01
+  d: 0.01
+  i_clamp: 0.0
+rear_right_wheel:
   p: 0.01
   i: 0.01
   d: 0.01

--- a/khan_control/include/khan_control/KHANHWInterface.h
+++ b/khan_control/include/khan_control/KHANHWInterface.h
@@ -1,0 +1,68 @@
+/**
+ * Class Implementing the K.H.A.N. RobotHW Interface.
+ * \author: Jason Ziglar <jpz@vt.edu>
+ * \date: 10/28/2015
+ */
+#ifndef _KHAN_HW_INTERFACE_H_
+#define _KHAN_HW_INTERFACE_H_
+
+#include <sensor_msgs/JointState.h>
+#include <hardware_interface/robot_hw.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <transmission_interface/transmission_info.h>
+#include <control_toolbox/pid.h>
+#include <ros/ros.h>
+
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/mutex.hpp>
+#include <string>
+
+namespace khan
+{
+
+/**
+ * Structure storing relevant JointData. Class for copy constructors
+ */
+class JointData
+{
+public:
+  JointData(const std::string& name);
+  JointData(const JointData& rhs);
+  ~JointData();
+
+  void update(const sensor_msgs::JointState::ConstPtr& msg);
+
+  std::string _name;
+  double _vel_cmd;
+  double _vel;
+  double _pos;
+  double _effort;
+  control_toolbox::Pid _controller;
+  ros::Subscriber _input;
+  ros::Publisher _output;
+  boost::mutex _mutex;
+};
+
+/**
+ * HWInterface for connecting to K.H.A.N. over a separate Python interface.
+ * This is not the recommended way to do this, but is useful for educational purposes.
+ */
+class KHANHWInterface : public hardware_interface::RobotHW
+{
+public:
+  KHANHWInterface(const std::string& robot_ns = "/");
+  virtual ~KHANHWInterface();
+
+  //void read(ros::Time time, ros::Duration period);
+  void write(ros::Time time, ros::Duration period);
+private:
+  hardware_interface::JointStateInterface _js_interface;
+  hardware_interface::VelocityJointInterface _vj_interface;
+  //! List of joints that have interfaces defined
+  std::vector<transmission_interface::TransmissionInfo> _transmissions;
+  std::vector<boost::shared_ptr<JointData> > _joints;
+};
+
+} //end namespace khan
+
+#endif

--- a/khan_control/launch/hardware.launch
+++ b/khan_control/launch/hardware.launch
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <launch>
   <node name="khan" pkg="khan_control" type="khan_control">
-    <param name="robot_ns" value="/" />
+    <param name="robot_ns" value="" />
     <param name="period" value="0.02" />
   </node>
 </launch>

--- a/khan_control/launch/hardware.launch
+++ b/khan_control/launch/hardware.launch
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<launch>
+  <node name="khan" pkg="khan_control" type="khan_control">
+    <param name="robot_ns" value="/" />
+    <param name="period" value="0.02" />
+  </node>
+</launch>

--- a/khan_control/package.xml
+++ b/khan_control/package.xml
@@ -16,6 +16,22 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roslaunch</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>controller_manager</build_depend>
+  <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>transmission_interface</build_depend>
+  <build_depend>control_toolbox</build_depend>
+  <build_depend>urdf</build_depend>
+  <run_depend>transmission_interface</run_depend>
+  <run_depend>control_toolbox</run_depend>
+  <run_depend>urdf</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>hardware_interface</run_depend>
+  <run_depend>controller_manager</run_depend>
+  <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>diff_drive_controller</run_depend>
   <run_depend>joint_state_controller</run_depend>
   <run_depend>joint_trajectory_controller</run_depend>

--- a/khan_control/src/KHANHWInterface.cpp
+++ b/khan_control/src/KHANHWInterface.cpp
@@ -98,6 +98,7 @@ KHANHWInterface::KHANHWInterface(const std::string& robot_ns) :
 {
   ros::NodeHandle nh(robot_ns);
   std::string rd_param;
+
   if(!nh.searchParam("robot_description", rd_param))
   {
     ROS_WARN_STREAM_NAMED("KHANHWInterface", " Cannot find URDF from parameter server. Bailing.");
@@ -162,6 +163,9 @@ KHANHWInterface::KHANHWInterface(const std::string& robot_ns) :
     //init PID controller for this joint
     j_info._controller.init(control_base, true);
   }
+
+  registerInterface(&_js_interface);
+  registerInterface(&_vj_interface);
 }
 
 /**

--- a/khan_control/src/KHANHWInterface.cpp
+++ b/khan_control/src/KHANHWInterface.cpp
@@ -187,7 +187,8 @@ void KHANHWInterface::write(ros::Time time, ros::Duration period)
     boost::mutex::scoped_lock lock(data._mutex);
     double error = data._vel_cmd - data._vel;
     //Compute PID command
-    const double new_vel = data._controller.computeCommand(error, period);
+    const double new_vel = data._vel_cmd + data._controller.computeCommand(error, period);
+    data._controller.printValues();
     //Package into message
     sensor_msgs::JointState msg;
     msg.header.stamp = time;

--- a/khan_control/src/KHANHWInterface.cpp
+++ b/khan_control/src/KHANHWInterface.cpp
@@ -1,0 +1,198 @@
+/**
+ * K.H.A.N. RobotHW Interface
+ * \author: Jason Ziglar <jpz@vt.edu>
+ * \date: 10/28/2015
+ */
+#include "khan_control/KHANHWInterface.h"
+#include <transmission_interface/transmission_parser.h>
+
+#include <urdf/model.h>
+
+#include <boost/function.hpp>
+#include <boost/bind.hpp>
+
+using namespace std;
+
+namespace khan
+{
+
+bool IsVelocityJointInterface(transmission_interface::JointInfo info)
+{
+  const string InterfaceName = "VelocityJointInterface";
+  for(vector<string>::iterator ii = info.hardware_interfaces_.begin();
+    ii != info.hardware_interfaces_.end(); ++ii)
+  {
+    if(*ii == InterfaceName)
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+JointData::JointData(const std::string& name) :
+  _name(name),
+  _vel_cmd(0.0),
+  _vel(0.0),
+  _pos(0.0),
+  _effort(0.0),
+  _controller(),
+  _input(),
+  _output(),
+  _mutex()
+{
+}
+
+JointData::JointData(const JointData& rhs) :
+  _name(rhs._name),
+  _vel_cmd(rhs._vel_cmd),
+  _vel(rhs._vel),
+  _pos(rhs._pos),
+  _effort(rhs._pos),
+  _controller(rhs._controller),
+  _input(rhs._input),
+  _output(rhs._output),
+  _mutex()
+{
+}
+
+JointData::~JointData()
+{
+}
+
+void JointData::update(const sensor_msgs::JointState::ConstPtr& msg)
+{
+  if(msg->name.empty())
+  {
+    ROS_WARN_STREAM_NAMED("KHANHWInterface", _name << " had an invalid JointState message, ignoring.");
+    return;
+  }
+
+  boost::mutex::scoped_lock lock(_mutex);
+  size_t counter = 0;
+
+  for(; counter < msg->name.size(); ++counter)
+  {
+    if(msg->name[counter] == _name)
+    {
+      break;
+    }
+  }
+
+  if(counter == msg->name.size())
+  {
+    return;
+  }
+
+  _pos = msg->position[counter];
+  _vel = msg->velocity[counter];
+}
+
+KHANHWInterface::KHANHWInterface(const std::string& robot_ns) :
+  hardware_interface::RobotHW(),
+  _js_interface(),
+  _vj_interface(),
+  _transmissions(),
+  _joints()
+{
+  ros::NodeHandle nh(robot_ns);
+  std::string rd_param;
+  if(!nh.searchParam("robot_description", rd_param))
+  {
+    ROS_WARN_STREAM_NAMED("KHANHWInterface", " Cannot find URDF from parameter server. Bailing.");
+    return;
+  }
+  string urdf_string;
+  nh.getParam(rd_param, urdf_string);
+
+  // urdf::Model model;
+
+  // if(!model.initString(urdf_string))
+  // {
+  //   ROS_WARN_STREAM_NAMED("KHANHWInterface", " Cannot parse URDF string");
+  //   return;
+  // }
+
+  transmission_interface::TransmissionParser::parse(urdf_string, _transmissions);
+  _joints.reserve(_transmissions.size());
+
+  for(vector<transmission_interface::TransmissionInfo>::iterator ii = _transmissions.begin();
+    ii != _transmissions.end(); ++ii)
+  {
+    if(ii->joints_.empty())
+    {
+      ROS_WARN_STREAM_NAMED("KHANHWInterface", ii->name_ << " does not have any joints assigned.");
+      continue;
+    }
+
+    //grab first VelocityJointInterface in the transmission
+    vector<transmission_interface::JointInfo>::iterator joint = std::find_if(ii->joints_.begin(), ii->joints_.end(),
+      IsVelocityJointInterface);
+
+    if(joint == ii->joints_.end())
+    {
+      ROS_WARN_STREAM_NAMED("KHANHWInterface", ii->name_ <<
+        " has no valid joints with a velocity interface to control");
+      continue;
+    }
+
+    _joints.push_back(boost::make_shared<JointData>(joint->name_));
+
+    JointData& j_info = *_joints.back();
+    hardware_interface::JointStateHandle base_handle =
+      hardware_interface::JointStateHandle(j_info._name, &j_info._pos,
+        &j_info._vel, &j_info._effort);
+
+    _js_interface.registerHandle(base_handle);
+
+    hardware_interface::JointHandle vel_handle = hardware_interface::JointHandle(base_handle,
+      &j_info._vel_cmd);
+    _vj_interface.registerHandle(vel_handle);
+
+    //Note all pub/sub is assumed to be in $robot_ns/py_controller/joint_name
+    //Inside, a JointState topic named encoder should exist, which the Python node publishes
+    //joint updates
+    //Inside, a JointState topic named cmd should exist, which the Python node reads for
+    //velocity commands
+    const string control_base = robot_ns + "/py_controller/" + j_info._name;
+    j_info._input = nh.subscribe(control_base + "/encoder", 10,
+      &JointData::update, &j_info);
+    j_info._output = nh.advertise<sensor_msgs::JointState>(control_base + "/cmd", 10);
+    //init PID controller for this joint
+    j_info._controller.init(control_base, true);
+  }
+}
+
+/**
+ * Default destructor
+ */
+KHANHWInterface::~KHANHWInterface()
+{
+}
+
+/**
+ * Write commands to every joint on the robot
+ */
+void KHANHWInterface::write(ros::Time time, ros::Duration period)
+{
+  //For every controlled joint
+  for(vector<boost::shared_ptr<JointData> >::iterator ii = _joints.begin(); ii != _joints.end(); ++ii)
+  {
+    JointData& data = **ii;
+    boost::mutex::scoped_lock lock(data._mutex);
+    double error = data._vel_cmd - data._vel;
+    //Compute PID command
+    const double new_vel = data._controller.computeCommand(error, period);
+    //Package into message
+    sensor_msgs::JointState msg;
+    msg.header.stamp = time;
+    msg.header.frame_id = data._name;
+    msg.name.push_back(data._name);
+    msg.velocity.push_back(new_vel);
+    //Publish commanded message
+    data._output.publish(msg);
+  }
+}
+
+}

--- a/khan_control/src/KHANPythonControl.cpp
+++ b/khan_control/src/KHANPythonControl.cpp
@@ -14,6 +14,7 @@ khan::KHANHWInterface* HWInterface = NULL;
 void updateHW(const ros::TimerEvent& event)
 {
   CM->update(event.current_real, event.current_real - event.last_real);
+  HWInterface->write(event.current_real, event.current_real - event.last_real);
 }
 
 int main(int argc, char** argv)

--- a/khan_control/src/KHANPythonControl.cpp
+++ b/khan_control/src/KHANPythonControl.cpp
@@ -37,5 +37,8 @@ int main(int argc, char** argv)
   CM = new controller_manager::ControllerManager(HWInterface);
   ros::Timer timer = nhp.createTimer(ros::Duration(period), updateHW);
 
-  ros::spin();
+  ros::MultiThreadedSpinner spinner(2);
+  spinner.spin();
+
+  return 0;
 }

--- a/khan_control/src/KHANPythonControl.cpp
+++ b/khan_control/src/KHANPythonControl.cpp
@@ -24,15 +24,10 @@ int main(int argc, char** argv)
   std::string robot_ns;
   double period;
 
-  nhp.param("robot_namespace", robot_ns, std::string("/"));
+  nhp.param("robot_namespace", robot_ns, std::string(""));
   nhp.param("period", period, 1.0 / 50.0);
-
   //Ensure the namespace is valid
-  if(robot_ns.empty())
-  {
-    robot_ns = "/";
-  }
-  else if(robot_ns[robot_ns.length() - 1] != '/')
+  if(!robot_ns.empty() && robot_ns[robot_ns.length() - 1] != '/')
   {
     robot_ns = robot_ns + "/";
   }

--- a/khan_control/src/KHANPythonControl.cpp
+++ b/khan_control/src/KHANPythonControl.cpp
@@ -1,0 +1,45 @@
+/**
+ * ros_control node for commanding K.H.A.N. via Python
+ * \author: Jason Ziglar <jpz@vt.edu>
+ * \date: 10/28/2015
+ */
+#include "khan_control/KHANHWInterface.h"
+
+#include <ros/ros.h>
+#include <controller_manager/controller_manager.h>
+
+controller_manager::ControllerManager* CM = NULL;
+khan::KHANHWInterface* HWInterface = NULL;
+
+void updateHW(const ros::TimerEvent& event)
+{
+  CM->update(event.current_real, event.current_real - event.last_real);
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "KHANPythonControl");
+  ros::NodeHandle nhp("~");
+
+  std::string robot_ns;
+  double period;
+
+  nhp.param("robot_namespace", robot_ns, std::string("/"));
+  nhp.param("period", period, 1.0 / 50.0);
+
+  //Ensure the namespace is valid
+  if(robot_ns.empty())
+  {
+    robot_ns = "/";
+  }
+  else if(robot_ns[robot_ns.length() - 1] != '/')
+  {
+    robot_ns = robot_ns + "/";
+  }
+
+  HWInterface = new khan::KHANHWInterface(robot_ns);
+  CM = new controller_manager::ControllerManager(HWInterface);
+  ros::Timer timer = nhp.createTimer(ros::Duration(period), updateHW);
+
+  ros::spin();
+}

--- a/khan_launch/launch/example_khan_hw.launch
+++ b/khan_launch/launch/example_khan_hw.launch
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<launch>
+   <include file="$(find khan_description)/launch/description.launch">
+    <arg name="is_sim" value="0"/>
+  </include>
+  <include file="$(find khan_control)/launch/hardware.launch" />
+  <include file="$(find khan_control)/launch/control.launch" />
+</launch>

--- a/khan_launch/launch/example_khan_hw.launch
+++ b/khan_launch/launch/example_khan_hw.launch
@@ -3,6 +3,8 @@
    <include file="$(find khan_description)/launch/description.launch">
     <arg name="is_sim" value="0"/>
   </include>
+  <!-- For a real robot, these parameters should be set for tuning individual motors -->
+  <rosparam command="load" file="$(find khan_control)/config/example_khan.yaml"  ns="/py_controller/"/>
   <include file="$(find khan_control)/launch/hardware.launch" />
   <include file="$(find khan_control)/launch/control.launch" />
 </launch>


### PR DESCRIPTION
This adds a ros_control interface that can interface with a separate node to do the hardware interfacing. Not how ros_control would prefer it, but useful for educational purposes.

The example setup can be started with `roslaunch khan_launch example_khan_hw.launch` - note that this does not start any remote node, so it only allows verifying the ros_control portion is working. Implementing the outstanding ROS node is an exercise left to the reader.
